### PR TITLE
update and sync with oficial skin chameleon from kolab 20190606 and updated to 0.3.11

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -4,5 +4,5 @@
 	"author": "Kolab Systems AG, Zurich, Switzerland",
 	"license": "GNU Affero General Public License",
 	"license-url": "http://www.gnu.org/licenses/agpl.html",
-	"version": "0.3.9"
+	"version": "0.3.11"
 }

--- a/styles.less
+++ b/styles.less
@@ -174,6 +174,7 @@ body.login #header {
 #mainscreencontent,
 #tasksview,
 .tasklistview #tagsbox,
+#tasklistbox,
 #folderlistbox,
 #filelistcontainer,
 #fileinfobox,
@@ -435,6 +436,10 @@ body.login #header {
 	background-position: -5px -2959px;
 }
 
+#ktaskpopup a.button-chat .button-inner {
+	background-image: none; /* TODO */
+}
+
 .ktaskmenu .dropdownhandle {
 	position: absolute;
 	display: block;
@@ -614,7 +619,8 @@ ul.listing.focus .listitem.focused span {
 	outline: none;
 }
 
-ul.treelist li.selected a:focus {
+ul.treelist li.selected > div > a:focus,
+ul.treelist li.selected > a:focus {
 	color: @list-selected-text !important;
 }
 
@@ -1814,6 +1820,8 @@ a.button.changeformat.text.selected span.icon {
 .attachmentslist li.doc,
 .attachmentslist li.docx,
 .attachmentslist li.msword,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_wordprocessingml_document span,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_wordprocessingml_template span,
 .filelist tbody td.filename.application_vnd_ms_word span,
 .filelist tbody td.filename.application_msword span {
 	background-position: 0 -52px;
@@ -1823,6 +1831,8 @@ a.button.changeformat.text.selected span.icon {
 .attachmentslist li.xlsx,
 .attachmentslist li.msexcel,
 .filelist tbody td.filename.application_vnd_ms_excel span,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_spreadsheetml_sheet span,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_spreadsheetml_template span,
 .filelist tbody td.filename.application_vnd_oasis_opendocument_spreadsheet span,
 .filelist tbody td.filename.application_vnd_oasis_opendocument_spreadsheet_template span {
 	background-position: 0 -104px;
@@ -1831,6 +1841,9 @@ a.button.changeformat.text.selected span.icon {
 .attachmentslist li.ppt,
 .attachmentslist li.pptx,
 .attachmentslist li.mspowerpoint,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_presentationml_presentation span,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_presentationml_template span,
+.filelist tbody td.filename.application_vnd_openxmlformats_officedocument_presentationml_slideshow span,
 .filelist tbody td.filename.application_vnd_ms_powerpoint span {
 	background-position: 0 -156px;
 }
@@ -2223,12 +2236,32 @@ a.button.changeformat.text.selected span.icon {
 	color: @text-color;
 }
 
-#tasklistsbox .treelist li.selected > div span.listname,
-#calendars .treelist li.selected > div span.calname,
-#directorylist li.addressbook.selected > div a,
-.notesview #notebooks li.selected > div .listname,
-#files-folder-list ul li.selected > span.name {
+.treelist li > div > a {
+	color: @list-text !important;
+}
+
+.treelist li > div.virtual > a {
+	color: #aaa !important;
+}
+
+.treelist li > div > a,
+#files-folder-list ul li > .name {
+	top: 3px !important;
+}
+
+.treelist li.selected > div > a,
+#files-folder-list ul li.selected > .name {
 	color: @list-selected-text !important;
+}
+
+.treelist li.selected > div > a,
+#files-folder-list ul li.selected > .name {
+	color: @list-selected-text !important;
+}
+
+html.mozilla .treelist li > div > input {
+	top: 2px !important;
+	left: 15px !important;
 }
 
 #directorylist li.addressbook.readonly {
@@ -2542,7 +2575,7 @@ a.button.changeformat.text.selected span.icon {
 	height: 47px;
 }
 
-.calendarmain .fc-content {
+#calendar > .fc-content {
 	top: 47px;
 }
 
@@ -2566,40 +2599,57 @@ a.button.changeformat.text.selected span.icon {
 	background-position: center -810px;
 }
 
+.calendarmain #calendar .fc-left .fc-button,
 .calendarmain #calendar .fc-header-left .fc-button {
 	background-image: url(images/buttons.png);
 }
 
+.calendarmain #calendar .fc-left .fc-agendaDay-button,
 .calendarmain #calendar .fc-header-left .fc-button-agendaDay {
 	background-position: center -1864px;
 }
 
+.calendarmain #calendar .fc-left .fc-agendaDay-button.fc-state-active,
 .calendarmain #calendar .fc-header-left .fc-button-agendaDay.fc-state-active {
 	background-position: center -1904px;
 }
 
+.calendarmain #calendar .fc-left .fc-agendaWeek-button,
 .calendarmain #calendar .fc-header-left .fc-button-agendaWeek {
 	background-position: center -1944px;
 }
 
+.calendarmain #calendar .fc-left .fc-agendaWeek-button.fc-state-active,
 .calendarmain #calendar .fc-header-left .fc-button-agendaWeek.fc-state-active {
 	background-position: center -1984px;
 }
 
+.calendarmain #calendar .fc-left .fc-month-button,
 .calendarmain #calendar .fc-header-left .fc-button-month {
 	background-position: center -2024px;
 }
 
+.calendarmain #calendar .fc-left .fc-month-button.fc-state-active,
 .calendarmain #calendar .fc-header-left .fc-button-month.fc-state-active {
 	background-position: center -2064px;
 }
 
+.calendarmain #calendar .fc-left .fc-list-button,
 .calendarmain #calendar .fc-header-left .fc-button-table {
 	background-position: center -2104px;
 }
 
+.calendarmain #calendar .fc-left .fc-list-button.fc-state-active,
 .calendarmain #calendar .fc-header-left .fc-button-table.fc-state-active {
 	background-position: center -2144px;
+}
+
+.calendarmain #calendar .fc-toolbar.fc-header-toolbar {
+	margin-bottom: 16px;
+}
+
+.calendarmain #calendar .fc-header-toolbar .fc-right {
+	padding-top: 1px;
 }
 
 .calendarmain #calendar .fc-header-right {
@@ -2642,10 +2692,25 @@ a.button.changeformat.text.selected span.icon {
 
 .fc-view thead th.fc-widget-header {
 	color: @text-color;
+	padding: 9px 0;
 }
 
 .fc-view-table {
 	border: none;
+}
+
+tbody.fc-body > tr > .fc-widget-content,
+.fc-head-container,
+.fc-list-view {
+	border: 0 !important;
+}
+
+.fc-head-container {
+	border-bottom: 1px solid #ddd !important;
+}
+
+.fc-day-number {
+	color: #888;
 }
 
 .calendarmain .fc-view-table tr.fc-event td {
@@ -2661,7 +2726,9 @@ a.button.changeformat.text.selected span.icon {
 	background: @header-background;
 	border-radius: 0;
 	border: none;
-	padding: 9px 8px;
+	padding: 0 8px;
+	height: 43px;
+	line-height: 43px;
 }
 
 #agendaoptions label {


### PR DESCRIPTION
i take in consideration the laste own mades apart of the oficial, like the _Less top margin in toplogo_ or the _Fix light text on white background for input areas_ in sync with oficial kolab @filhocf 

* sync with https://cgit.kolab.org/roundcubemail-skin-chameleon https://cgit.kolab.org/roundcubemail-skin-chameleon/commit/?id=2066e3aa2db8e739ecebfbde4fe07ca51172c2e6
* Add missing labels to the env that fixes not localized "ERRORTITLE" stolen and
  sync from https://cgit.kolab.org/roundcubemail-skin-chameleon/commit/?id=e86bfcc496280fd5516d80a8af36c4ad24d57266
* Compatibility with fullCalendar 3.9 from https://cgit.kolab.org/roundcubemail-skin-chameleon/commit/?id=5a70e0dfdbb079b6aafc0665b29be5dd5bc04414
* Fix selected folder color in Files/Calendar/Tasks (T4371) stolen and
  sync from https://cgit.kolab.org/roundcubemail-skin-chameleon/commit/?id=5c6c59dc12b9870b836c0e30854df990db4d443e
* some other small fixes ( 5c6c59dc12b9870b836c0e30854df990db4d443e )
* compatibility with Kolab 14 from commit https://cgit.kolab.org/roundcubemail-skin-chameleon/commit/?id=fd8c71dc994b3cce5e5dd63d25976cd4dd3c6586